### PR TITLE
Resolve Windows 10 Bundle Install Issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,5 @@ gem 'middleman-livereload'
 
 gem 'slim'
 
-gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
-gem 'wdm', '~> 0.1', platforms: [:mswin, :mingw]
+gem 'tzinfo-data', platforms: [:mswin, :x64_mingw, :mingw, :jruby]
+gem 'wdm', '~> 0.1', platforms: [:mswin, :x64_mingw, :mingw]


### PR DESCRIPTION
This PR allows Windows 10 64-bit (and likely other versions of Windows) to successfully complete `bundle install`.  `mswin` targets the 32-bit version of Windows which is why the additional 64-bit specific platform is required.