### PR TITLE
Added webrick to Ruby Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'middleman-autoprefixer'
 gem 'middleman-blog'
 gem 'middleman-livereload'
 
+gem 'webrick'
 gem 'slim'
 
 gem 'tzinfo-data', platforms: [:mswin, :x64_mingw, :mingw, :jruby]


### PR DESCRIPTION
Added 'webrick' to the Ruby Gemfile as 'webrick' is not longer bundled in Ruby 3.0. Without 'webrick', the `docker-compose run` command in the README.md will not run properly.